### PR TITLE
Update bamazonCustomer-promise.js

### DIFF
--- a/bamazonCustomer-promise.js
+++ b/bamazonCustomer-promise.js
@@ -21,7 +21,8 @@ function main() {
 };
 
 main()
-.then(displayAllItems)
+.then(getAllItems)
+.then(displayData)
 .then(itemBuy)
 
 
@@ -64,13 +65,23 @@ function itemBuy() {
 }
 
 // Display 
-function displayAllItems() {
+function getAllItems() {
+    return new Promise(resolve, reject) {
+        connection.query("SELECT * FROM product", function (err, data) {
+            if (err) reject(err);
+            
+            resolve(data);
+            data.forEach(function (elem) {
+                output += `\n${elem.item_id}:\t${elem.product_name} - ${elem.price}`
+            });
+        });   
+    }
+}
+
+function displayData(data) {
     output = '';
-    connection.query("SELECT * FROM product", function (err, data) {
-        if (err) throw err;
-        data.forEach(function (elem) {
-            output += `\n${elem.item_id}:\t${elem.product_name} - ${elem.price}`
-        });
-        console.log(output);
+    data.forEach(function (elem) {
+        output += `\n${elem.item_id}:\t${elem.product_name} - ${elem.price}`
     });
+    console.log(output);
 }


### PR DESCRIPTION
Problem was in that your original function to displayAllItems was not wrapped in a promise. Here's the full breakdown

You would connect then return a promise, that promise then executed displayAllItems which ran connection.query synchronously and returned nothing. The next promise then executed. 

To stop that from happening and for connection query to be looped into the main promise chain, it needed to be promisified and then returned to the chain. Once you return a promise to the original promise chain, it 'knows' that it needs to wait for the promisified connection.query to return before proceeding.